### PR TITLE
#164798286 Document API using swagger

### DIFF
--- a/authors/apps/authentication/views.py
+++ b/authors/apps/authentication/views.py
@@ -1,5 +1,5 @@
 from rest_framework import status
-from rest_framework.generics import RetrieveUpdateAPIView
+from rest_framework.generics import RetrieveUpdateAPIView, GenericAPIView
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -10,7 +10,7 @@ from .serializers import (
 )
 
 
-class RegistrationAPIView(APIView):
+class RegistrationAPIView(GenericAPIView):
     # Allow any user (authenticated or not) to hit this endpoint.
     permission_classes = (AllowAny,)
     renderer_classes = (UserJSONRenderer,)
@@ -29,7 +29,7 @@ class RegistrationAPIView(APIView):
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
 
-class LoginAPIView(APIView):
+class LoginAPIView(GenericAPIView):
     permission_classes = (AllowAny,)
     renderer_classes = (UserJSONRenderer,)
     serializer_class = LoginSerializer

--- a/authors/settings.py
+++ b/authors/settings.py
@@ -15,6 +15,7 @@ import django_heroku
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.11/howto/deployment/checklist/
@@ -39,7 +40,7 @@ INSTALLED_APPS = [
     'corsheaders',
     'django_extensions',
     'rest_framework',
-
+    'rest_framework_swagger',
     'authors.apps.authentication',
     'authors.apps.core',
     'authors.apps.profiles',
@@ -140,6 +141,16 @@ AUTH_USER_MODEL = 'authentication.User'
 REST_FRAMEWORK = {
     'EXCEPTION_HANDLER': 'authors.apps.core.exceptions.core_exception_handler',
     'NON_FIELD_ERRORS_KEY': 'error'
+}
+
+SWAGGER_SETTINGS = {
+   'SECURITY_DEFINITIONS': {
+       'api_key': {
+           'type': 'apiKey',
+           'in': 'header',
+           'name': 'Authorization'
+       }
+   },
 }
 
 django_heroku.settings(locals())

--- a/authors/urls.py
+++ b/authors/urls.py
@@ -16,11 +16,14 @@ Including another URLconf
 
 from django.urls import path, include
 from django.contrib import admin
+from rest_framework_swagger.views import get_swagger_view
+
+schema_view = get_swagger_view(title='Authors Heaven')
 
 app_name = "authors-haven" 
 urlpatterns = [
     path('admin/', admin.site.urls),
-
+    path('swagger-docs/', schema_view),
     path('api/', include('authors.apps.authentication.urls')),
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,8 @@ astroid==2.2.5
 certifi==2019.3.9
 cffi==1.12.2
 chardet==3.0.4
+coreapi==2.3.3
+coreschema==0.0.4
 coverage==4.5.3
 coveralls==1.7.0
 cryptography==2.6.1
@@ -11,6 +13,7 @@ Django==2.1.7
 django-cors-headers==2.5.2
 django-extensions==2.1.6
 django-heroku==0.3.1
+django-rest-swagger==2.2.0
 djangorestframework==3.9.2
 docopt==0.6.2
 entrypoints==0.3
@@ -18,9 +21,13 @@ flake8==3.7.7
 gunicorn==19.9.0
 idna==2.8
 isort==4.3.16
+itypes==1.1.0
+Jinja2==2.10
 jwt==0.6.1
 lazy-object-proxy==1.3.1
+MarkupSafe==1.1.1
 mccabe==0.6.1
+openapi-codec==1.3.2
 psycopg2==2.7.7
 psycopg2-binary==2.7.7
 pycodestyle==2.5.0
@@ -30,8 +37,10 @@ PyJWT==1.7.1
 pylint==2.3.1
 pytz==2018.9
 requests==2.21.0
+simplejson==3.16.0
 six==1.12.0
 typed-ast==1.3.1
+uritemplate==3.0.0
 urllib3==1.24.1
 whitenoise==4.1.2
 wrapt==1.11.1


### PR DESCRIPTION
**What does this PR do?**
Creates API documentation using Swagger

**Description of the task to be completed?**

- Install django-rest-swagger

- Add rest_framework_swagger to Installed apps in settings.py file

- Add a url that navigates to the swagger documentation in urls.py file

- Replace ApiView with GenericApiView in the class-based views in views.py file

**How should this be manually tested?**

- Clone the repository using the command below and cd into it
   `git clone https://github.com/andela/ah-backend-prime.git`

- Checkout the branch 
   `git checkout ft-setup-swagger-164798286`

- Run the application
   `python manage.py runserver`

- Navigate to the url below to view and test out the API Swagger documentation
   http://127.0.0.1:8000/swagger-docs/

**What are the relevant pivotal tracker stories?**
[#164798286](https://www.pivotaltracker.com/story/show/164798286)

**Screenshots**

<img width="1436" alt="Screen Shot 2019-03-30 at 02 27 44" src="https://user-images.githubusercontent.com/26630001/55267488-8a91ec80-5293-11e9-9134-f8f5634b213d.png">

