### PR TITLE
#165885347 Fix social auth for already registered user

### DIFF
--- a/authors/apps/authentication/tests/test_data.py
+++ b/authors/apps/authentication/tests/test_data.py
@@ -5,6 +5,15 @@ VALID_USER_DATA = {
         "password": "1234!@#$Aa"
     }
 }
+
+VALID_USER_DATA_FOR_USER = {
+    "user": {
+        "username": "anyatijude",
+        "email": "anyatibrian@glo.com",
+        "password": "Password@123"
+    }
+}
+
 VALID_USER_DATA_2 = {
     "user": {
         "username": "fitzokou",
@@ -97,6 +106,12 @@ VALID_LOGIN_DATA = {
     "user": {
         "email": "anyatibrian@glo.com",
         "password": "1234!@#$Aa"
+    }
+}
+VALID_LOGIN_DATA_FOR_USER = {
+    "user": {
+        "email": "anyatibrian@glo.com",
+        "password": "Password@123"
     }
 }
 LOGIN_RESPONSE = {'email': 'anyatijude@glo.com', 'username': 'anyatijude'}

--- a/authors/apps/social_auth/register.py
+++ b/authors/apps/social_auth/register.py
@@ -27,9 +27,12 @@ def register_user(email, username):
         }
         return data
     else:
-        registered_user = authenticate(email=email, password=password)
-        return {
-            'email': registered_user.email,
-            'username': registered_user.username,
-            'token': registered_user.token,
-        }
+        try:
+            registered_user = authenticate(email=email, password=password)
+            return {
+                'email': registered_user.email,
+                'username': registered_user.username,
+                'token': registered_user.token,
+            }
+        except:
+            return "Kindly log In using the application."


### PR DESCRIPTION
**What does this PR do?**
    Fixes social authentication response when an already registered user in the system tries to log in using a social authentication platform

**How should this be manually tested?**

- Checkout [Pull Request :34](https://github.com/andela/ah-backend-prime/pull/34) on this

**What are the relevant pivotal tracker stories?**
    [#165885347](https://www.pivotaltracker.com/story/show/165885347)