### PR TITLE
#166087158 Enable Users get articles by a particular user

### DIFF
--- a/authors/apps/articles/filters.py
+++ b/authors/apps/articles/filters.py
@@ -2,6 +2,7 @@ from django_filters import rest_framework as filters
 from django_filters import FilterSet
 from authors.apps.articles.models import Articles
 
+
 class ArticleFilter(FilterSet):
     """
     class handling the filtering of articles:
@@ -15,6 +16,9 @@ class ArticleFilter(FilterSet):
     author = filters.CharFilter('author__user__username',
                                 lookup_expr='icontains'
                                 )
+    email = filters.CharFilter('author__user__email',
+                               lookup_expr='icontains'
+                               )
     title = filters.CharFilter(lookup_expr='icontains')
     tagsList = filters.CharFilter('tagsList', method='filter_tags')
 


### PR DESCRIPTION
### What does this PR do?
Enable Users to get articles by a particular user

#### Description of Task to be completed?
- Update search filter to enable one get articles specific to a particular user

#### How should this be manually tested?
After cloning the repo, cd into it and run the following commands to activate the virtual environment

- `$ virtualenv venv`
- `$ source venv/bin/activate`

Checkout this branch
- `$ git checkout  ft-get-user-articles-166087158 `

Install all requirements

- `$ pip install -r requirements.txt`

Source the environment variables

- `$ source .env`

Run the migrations

- `$ python manage.py migrate`

Run the server

- `$ python manage.py runserver`

In your browser,  place this url `http://localhost:8000/swagger-docs/`
In the articles tag, click the tryout button and in the field of email, enter an email and click execute to view articles by an author based on their email address

#### Any background context you want to provide?
Prior to this searching for articles by a user was by username which brings about a lot of ambiguity. 
If one searches for articles by 'ed', they'd get articles by 'ed', 'edd' and 'eddie'.
However, now if one searches for articles by email, they only get articles specific to the author based on their email

#### What are the relevant pivotal tracker stories?
[#166087158](https://www.pivotaltracker.com/story/show/166087158)

#### Screenshots 

<img width="1438" alt="Screenshot 2019-05-18 at 18 02 33" src="https://user-images.githubusercontent.com/43245704/57971490-92b70000-7997-11e9-854f-e73ec5fd5394.png">

<img width="1438" alt="Screenshot 2019-05-18 at 18 03 55" src="https://user-images.githubusercontent.com/43245704/57971491-92b70000-7997-11e9-97e2-23f84b92568d.png">

<img width="1438" alt="Screenshot 2019-05-18 at 18 04 20" src="https://user-images.githubusercontent.com/43245704/57971492-934f9680-7997-11e9-9842-fed48795ff82.png">
